### PR TITLE
Fix the regex for parsing and extracting log

### DIFF
--- a/parsers.conf
+++ b/parsers.conf
@@ -1,5 +1,5 @@
 [PARSER]
     Name        raw-log
     Format      regex
-    Regex       ^[^ ]+\s+(stdout|stderr)\s+(F|P)\s+(?<log>.*)$
+    Regex       ^[^ ]+ (stdout|stderr) (F|P) (?<log>.*)$
     Time_Keep   Off


### PR DESCRIPTION
Fixing the regex to not trim whitespace at the start of a log line. This was breaking indents and formatting. The `\s+` was trimming all whitespace, when really all we need is to trim a single space.